### PR TITLE
Add LICENSE, CITATION.cff, and credits

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,25 @@
+cff-version: 1.2.0
+message: "If you use UMR Writer in your research, please cite it as below."
+title: "UMR Writer"
+abstract: >-
+  UMR Writer is a web-based annotation tool, extending AMR Editor, that allows
+  annotators to create both sentence-level and document-level Uniform Meaning
+  Representation (UMR) annotations across multiple languages.
+type: software
+authors:
+  - family-names: Zhao
+    given-names: Jin
+    affiliation: Brandeis University
+    # orcid: "https://orcid.org/0000-0000-0000-0000"  # add your ORCID if you have one
+  - family-names: Ge
+    given-names: Sijia
+    affiliation: Brandeis University
+repository-code: "https://github.com/jinzhao3611/umr-annotation-tool"
+license: MIT
+keywords:
+  - UMR
+  - Uniform Meaning Representation
+  - semantic annotation
+  - natural language processing
+  - computational linguistics
+date-released: 2020-08-23

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-2026 Jin Zhao and Brandeis University
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -97,3 +97,27 @@ The application uses the following main tables:
 - `doc_version` - Document versions
 - `annotation` - Sentence and document annotations
 - `lexicon`, `lattice`, `partialgraph` - Project-specific data
+
+## Credits
+
+UMR Writer was created and is primarily developed by **Jin Zhao** (Brandeis
+University), who originated the project in 2020 and authored the large majority
+of its codebase.
+
+Contributors:
+
+- **Jin Zhao** — creator and lead developer
+- **Sijia (Konic) Ge** — contributor
+
+The project is developed under the UMR project at Brandeis University.
+
+## Citation
+
+If you use UMR Writer in your research, please cite it using the metadata in
+[`CITATION.cff`](CITATION.cff) (GitHub renders a "Cite this repository" button
+from this file).
+
+## License
+
+This project is licensed under the MIT License — see the [`LICENSE`](LICENSE)
+file for details. Copyright (c) 2020-2026 Jin Zhao and Brandeis University.


### PR DESCRIPTION
Establish explicit attribution and licensing before transferring the repository to the UMR project organization.

## Changes
- **LICENSE** — MIT, Copyright (c) 2020-2026 Jin Zhao and Brandeis University (repo previously had no license)
- **CITATION.cff** — makes the project citable; GitHub renders a "Cite this repository" button. Jin Zhao listed as primary author, Sijia Ge as contributor
- **README** — added Credits, Citation, and License sections

## Notes
- Add your ORCID to `CITATION.cff` if you have one (commented placeholder is in place)
- Adjust Sijia Ge's contributor description if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)